### PR TITLE
Fix brand not being sent to Nosto

### DIFF
--- a/classes/helpers/product-operation.php
+++ b/classes/helpers/product-operation.php
@@ -211,7 +211,7 @@ class NostoTaggingHelperProductOperation
      */
     protected function loadNostoProduct($id_product, $id_lang, $id_shop)
     {
-        $product = new Product($id_product, false, $id_lang, $id_shop);
+        $product = new Product($id_product, true, $id_lang, $id_shop);
         if (!Validate::isLoadedObject($product)) {
             return null;
         }


### PR DESCRIPTION
If "full" option is not set when creating Product objects from Prestashop database, the "manufacturer_name"' property will be blank. This precludes his transmission to Nosto.