### PR TITLE
Do not render notification on ajax response

### DIFF
--- a/nostotagging.php
+++ b/nostotagging.php
@@ -49,6 +49,7 @@ if ((basename(__FILE__) === 'nostotagging.php')) {
  */
 class NostoTagging extends Module
 {
+    const AJAX_REQUEST_PARAMETER_KEY = 'ajax';
     /** @var bool */
     public $bootstrap;
     /**
@@ -884,7 +885,9 @@ class NostoTagging extends Module
     public function hookDisplayBackOfficeTop()
     {
         //Do not render any thing when it is a ajax request
-        if ($_REQUEST['ajax'] != 1) {
+        if (array_key_exists(self::AJAX_REQUEST_PARAMETER_KEY, $_REQUEST)
+            && $_REQUEST[self::AJAX_REQUEST_PARAMETER_KEY] != 1
+        ) {
             NostoNotificationManager::checkAndDisplay($this);
         }
     }

--- a/nostotagging.php
+++ b/nostotagging.php
@@ -883,7 +883,10 @@ class NostoTagging extends Module
      */
     public function hookDisplayBackOfficeTop()
     {
-        NostoNotificationManager::checkAndDisplay($this);
+        //Do not render any thing when it is a ajax request
+        if ($_REQUEST['ajax'] != 1) {
+            NostoNotificationManager::checkAndDisplay($this);
+        }
     }
 
     /**


### PR DESCRIPTION
It causes problem on some prestashop feature using ajax request to fetch data from prestashop backend. For example search customer on order creation page.