### PR TITLE
Hotfix 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning(http://semver.org/).
 
+## 3.3.2
+- Fixed a bug that after upgrading nosto from 2.x to 3.x, some of the nosto controllers and hooks are not registered to prestashop
+
 ## 3.3.1
 - Fixed a bug that nosto injects html content to prestashop ajax responses on older prestashop version
 

--- a/classes/managers/NostoAdminTabManager.php
+++ b/classes/managers/NostoAdminTabManager.php
@@ -144,7 +144,7 @@ class NostoAdminTabManager
         /** @noinspection PhpDeprecationInspection */
         $tab->id = (int)Tab::getIdFromClassName($className);
         $tab->active = true;
-        $languageIds = Language::getLanguages(true, false, true);
+        $languageIds = Language::getLanguages(false, false, true);
         if ($languageIds) {
             $tab->name = array();
             foreach ($languageIds as $languageId) {

--- a/nostotagging.php
+++ b/nostotagging.php
@@ -56,7 +56,7 @@ class NostoTagging extends Module
      *
      * @var string
      */
-    const PLUGIN_VERSION = '3.3.1';
+    const PLUGIN_VERSION = '3.3.2';
 
     /**
      * Internal name of the Nosto plug-in

--- a/upgrade/upgrade-3.3.2.php
+++ b/upgrade/upgrade-3.3.2.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * 2013-2017 Nosto Solutions Ltd
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to contact@nosto.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2013-2017 Nosto Solutions Ltd
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Upgrades the module to version 3.3.2.
+ *
+ * Fix the controller registering issue
+ * @param $module Module
+ * @return bool
+ * @suppress PhanUnreferencedMethod
+ */
+function upgrade_module_3_3_2($module)
+{
+    $success = NostoAdminTabManager::uninstall() && NostoAdminTabManager::install();
+
+    $module->unregisterHook('actionCartSave');
+    $module->unregisterHook('actionCartUpdateQuantityBefore');
+    $module->unregisterHook('actionBeforeCartUpdateQty');
+
+    $module->registerHook('actionCartSave');
+    $module->registerHook('actionCartUpdateQuantityBefore');
+    $module->registerHook('actionBeforeCartUpdateQty');
+
+    $hooks = array(array(
+        'name' => 'actionNostoVariationKeyCollectionLoadAfter',
+        'title' => 'After load nosto variation key collection',
+        'description' => 'Action hook fired after a Nosto variation key collection has been initialized.',
+    ));
+    NostoHookManager::initHooks($hooks);
+
+    NostoHelperConfig::clearCache();
+
+    return $success;
+}


### PR DESCRIPTION
- Fixed a bug that after upgrading nosto from 2.x to 3.x, some of the nosto controllers and hooks are not registered to prestashop

Closes #225 
Closes #224 