### PR TITLE
Hotfix 3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning(http://semver.org/).
 
+## 3.4.2
+- Fixed a bug that customer tagging has been disabled by default on prestashop 1.6
+- Fixed a bug that it is not possible to enable or disable customer tagging
+
 ## 3.4.1
 - Fixed a issue that it failed to be installed to some special prestashop environments
 

--- a/classes/helpers/NostoHelperConfig.php
+++ b/classes/helpers/NostoHelperConfig.php
@@ -35,7 +35,7 @@ class NostoHelperConfig
     const MULTI_CURRENCY_METHOD = 'NOSTOTAGGING_MC_METHOD';
     const SKU_SWITCH = 'NOSTOTAGGING_SKU_SWITCH';
     const CART_UPDATE_SWITCH = 'NOSTOTAGGING_CART_UPDATE_SWITCH';
-    const CUSTOMER_TAGGING_SWITCH = 'NOSTOTAGGING_CUSTOMER_TAGGING_SWITCH';
+    const SKIP_CUSTOMER_TAGGING_SWITCH = 'NOSTOTAGGING_SKIP_CUSTOMER_TAGGING_SWITCH';
     const VARIATION_SWITCH = 'NOSTOTAGGING_VARIATION_SWITCH';
     const VARIATION_TAX_RULE_SWITCH = 'NOSTOTAGGING_TAX_RULE_SWITCH';
     const TOKEN_CONFIG_PREFIX = 'NOSTOTAGGING_API_TOKEN_';
@@ -378,17 +378,9 @@ class NostoHelperConfig
      */
     public static function isCustomerTaggingEnabled()
     {
-        //default value doesn't work in prestashop 1.6
-        $hasKey = Configuration::hasKey(
-            self::CUSTOMER_TAGGING_SWITCH,
-            NostoHelperContext::getLanguageId(),
-            NostoHelperContext::getShopGroupId(),
-            NostoHelperContext::getShopId()
-        );
-        if (!$hasKey) {
-            return true;
-        }
-        return (bool)self::read(self::CUSTOMER_TAGGING_SWITCH);
+        $skipped =  self::read(self::SKIP_CUSTOMER_TAGGING_SWITCH);
+
+        return !(bool)$skipped;
     }
 
     /**
@@ -399,7 +391,9 @@ class NostoHelperConfig
      */
     public static function saveCustomerTaggingEnabled($enabled)
     {
-        return self::saveSetting(self::CUSTOMER_TAGGING_SWITCH, $enabled);
+        $skipped = $enabled ? '0' : '1';
+
+        return self::saveSetting(self::SKIP_CUSTOMER_TAGGING_SWITCH, $skipped);
     }
 
     /**

--- a/classes/helpers/NostoHelperConfig.php
+++ b/classes/helpers/NostoHelperConfig.php
@@ -50,17 +50,15 @@ class NostoHelperConfig
      * Reads and returns a config entry value.
      *
      * @param string $name the name of the config entry in the db.
-     * @param bool $defaultValue
      * @return mixed
      */
-    private static function read($name, $defaultValue = false)
+    private static function read($name)
     {
         return Configuration::get(
             $name,
             NostoHelperContext::getLanguageId(),
             NostoHelperContext::getShopGroupId(),
-            NostoHelperContext::getShopId(),
-            $defaultValue
+            NostoHelperContext::getShopId()
         );
     }
 
@@ -380,7 +378,17 @@ class NostoHelperConfig
      */
     public static function isCustomerTaggingEnabled()
     {
-        return (bool)self::read(self::CUSTOMER_TAGGING_SWITCH, true);
+        //default value doesn't work in prestashop 1.6
+        $hasKey = Configuration::hasKey(
+            self::CUSTOMER_TAGGING_SWITCH,
+            NostoHelperContext::getLanguageId(),
+            NostoHelperContext::getShopGroupId(),
+            NostoHelperContext::getShopId()
+        );
+        if (!$hasKey) {
+            return true;
+        }
+        return (bool)self::read(self::CUSTOMER_TAGGING_SWITCH);
     }
 
     /**

--- a/controllers/admin/NostoAdvancedSettingController.php
+++ b/controllers/admin/NostoAdvancedSettingController.php
@@ -42,7 +42,7 @@ class NostoAdvancedSettingController extends NostoBaseController
         NostoHelperConfig::saveVariationEnabled(Tools::getValue('nosto_variation_switch'));
         NostoHelperConfig::saveVariationTaxRuleEnabled(Tools::getValue('nosto_variation_tax_rule_switch'));
         NostoHelperConfig::saveCartUpdateEnabled(Tools::getValue('nosto_cart_update_switch'));
-        NostoHelperConfig::saveCustomerTaggingEnabled(Tools::getValue('nosto_customer_switch'));
+        NostoHelperConfig::saveCustomerTaggingEnabled(Tools::getValue('nosto_customer_tagging_switch'));
 
         $account = NostoHelperAccount::getAccount();
         $accountMeta = NostoAccountSignup::loadData();

--- a/nostotagging.php
+++ b/nostotagging.php
@@ -56,7 +56,7 @@ class NostoTagging extends Module
      *
      * @var string
      */
-    const PLUGIN_VERSION = '3.4.1';
+    const PLUGIN_VERSION = '3.4.2';
 
     /**
      * Internal name of the Nosto plug-in


### PR DESCRIPTION
- Fixed a bug that customer tagging has been disabled by default on prestashop 1.6
- Fixed a bug that it is not possible to enable or disable customer tagging