### PR TITLE
Fix <head> tag closed by browser when HTML encountered in HookDisplayHeader

### DIFF
--- a/classes/blocks/NostoDefaultTagging.php
+++ b/classes/blocks/NostoDefaultTagging.php
@@ -39,7 +39,8 @@ class NostoDefaultTagging
         }
 
         $html = '';
-        $html .= NostoCustomerTagging::get();
+        $html .= NostoPageTypeTagging::get();
+	$html .= NostoCustomerTagging::get();
         $html .= NostoCartTagging::get();
         $html .= NostoVariationTagging::get();
         if (NostoHelperController::isController('category')) {

--- a/classes/blocks/NostoDefaultTagging.php
+++ b/classes/blocks/NostoDefaultTagging.php
@@ -40,7 +40,7 @@ class NostoDefaultTagging
 
         $html = '';
         $html .= NostoPageTypeTagging::get();
-	$html .= NostoCustomerTagging::get();
+        $html .= NostoCustomerTagging::get();
         $html .= NostoCartTagging::get();
         $html .= NostoVariationTagging::get();
         if (NostoHelperController::isController('category')) {

--- a/classes/blocks/NostoHeaderContent.php
+++ b/classes/blocks/NostoHeaderContent.php
@@ -62,7 +62,6 @@ class NostoHeaderContent
         $html .= $module->render('views/templates/hook/header_embed-script.tpl');
         $html .= $module->render('views/templates/hook/header_add-to-cart.tpl');
         $html .= $module->render('views/templates/hook/header_prestashop-add-to-cart-event-handler.tpl');
-        $html .= NostoPageTypeTagging::get();
 
         return $html;
     }


### PR DESCRIPTION
If you write HTML tags in `<head>` (like you do in classes/blocks/NostoHeaderContent.php when you call `NostoPageTypeTagging::get()`), the browsers will close the head tag.

Not sure if it's always like this, but with _modpagespeed_ activated it surely does and it breaks lots of things :-(