### PR TITLE
Feature - Configure CI to build plugin package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN         sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) m
 RUN         apt-get -y -qq update
 
 # Install all core dependencies required for setting up Apache and PHP atleast
-RUN         apt-get update && apt-get -y -q install unzip wget libfreetype6-dev libjpeg-dev \
+RUN         apt-get update && apt-get -y -q install zip unzip wget libfreetype6-dev libjpeg-dev \
             libmcrypt-dev libreadline-dev libpng-dev libicu-dev default-mysql-client \
             libmcrypt-dev libxml2-dev libxml2-utils libxslt1-dev vim nano git tree curl \
             supervisor ca-certificates && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
           version = sh(returnStdout: true, script: 'grep "const PLUGIN_VERSION = " nostotagging.php | cut -d= -f2 | tr "," " "| tr ";" " " | tr "\'" " "').trim()
           sh "./libs/bin/phing -Dversion=${version}"
         }
-        archiveArtifacts "build/package/NostoTagging-${version}.zip"
+        archiveArtifacts "build/package/${version}-Nosto.-.Personalization.for.PrestaShop.zip"
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,16 @@ pipeline {
         archiveArtifacts 'chkphan.xml'
       }
     }
+
+    stage('Package') {
+      steps {
+        script {
+          version = sh(returnStdout: true, script: 'grep "const PLUGIN_VERSION = " nostotagging.php | cut -d= -f2 | tr "," " "| tr ";" " " | tr "\'" " "').trim()
+          sh "./vendor/bin/phing -Dversion=${version}"
+        }
+        archiveArtifacts "build/package/NostoTagging-${version}.zip"
+      }
+    }
   }
 
   post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
       steps {
         script {
           version = sh(returnStdout: true, script: 'grep "const PLUGIN_VERSION = " nostotagging.php | cut -d= -f2 | tr "," " "| tr ";" " " | tr "\'" " "').trim()
-          sh "./vendor/bin/phing -Dversion=${version}"
+          sh "./libs/bin/phing -Dversion=${version}"
         }
         archiveArtifacts "build/package/NostoTagging-${version}.zip"
       }


### PR DESCRIPTION
## Description
Update Jenkinsfile to make use of Phing and archive the artifact with correct version number.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #285 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently unlike Magento 1, we do not build the ZIP file automatically. While Phing has support for it, we do not invoke it on CI. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Jenkins has archived the artifact
- [x] Package has been upload and tested in Prestashop Plugintest

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers