### PR TITLE
Hotfix - Sort Orders Import By Date Added Desc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning(http://semver.org/).
 
+## 3.6.3
+- Fix order import sorting
+
 ## 3.6.2
 - Fix missing language id parameter for Prestashop < 1.6 in item availability
 

--- a/controllers/front/order.php
+++ b/controllers/front/order.php
@@ -82,6 +82,7 @@ class NostoTaggingOrderModuleFrontController extends NostoTaggingApiModuleFrontC
                 SELECT id_order
                 FROM %sorders
                 WHERE %s
+                ORDER BY date_add DESC
                 LIMIT %d
                 OFFSET %d
             ',

--- a/nostotagging.php
+++ b/nostotagging.php
@@ -56,7 +56,7 @@ class NostoTagging extends Module
      *
      * @var string
      */
-    const PLUGIN_VERSION = '3.6.2';
+    const PLUGIN_VERSION = '3.6.3';
 
     /**
      * Internal name of the Nosto plug-in


### PR DESCRIPTION
## Description
The order import sorting might cause best sellers recos to be displayed with outdated purchases. This orders the import by the most recent buys.

## Related Issue
Fixes #287 

## How Has This Been Tested?
Tested with new nosto prestashop account and all orders were successfully imported in the correct order.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
