### PR TITLE
Add feature flag to disable/enable tagging auto-encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning(http://semver.org/).
 
+## 3.7.2
+- Add feature flag to enable/disable tagging auto encoding
+
 ## 3.7.1
 - Allow reconnecting same account to the same store in same language
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning(http://semver.org/).
 
-## 3.7.2
+## 3.8.0
 - Add feature flag to enable/disable tagging auto encoding
 
 ## 3.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning(http://semver.org/).
 
 ## 3.8.0
-- Add feature flag to enable/disable tagging auto encoding
+- Add feature flag to enable/disable search term escaping for Nosto tagging
 
 ## 3.7.1
 - Allow reconnecting same account to the same store in same language

--- a/classes/blocks/NostoSearchTagging.php
+++ b/classes/blocks/NostoSearchTagging.php
@@ -40,7 +40,7 @@ class NostoSearchTagging
             return null;
         }
         $searchTerm = new SearchTerm($searchQuery);
-        if (!NostoHelperConfig::isSearchTermEscapingEnabled()) {
+        if (NostoHelperConfig::isSearchTermEscapingDisabled()) {
             $searchTerm->disableAutoEncodeAll();
         }
         return $searchTerm->toHtml();

--- a/classes/blocks/NostoSearchTagging.php
+++ b/classes/blocks/NostoSearchTagging.php
@@ -40,7 +40,9 @@ class NostoSearchTagging
             return null;
         }
         $searchTerm = new SearchTerm($searchQuery);
-        $searchTerm->disableAutoEncodeAll();
+        if (!NostoHelperConfig::isTaggingEncodingEnabled()) {
+            $searchTerm->disableAutoEncodeAll();
+        }
         return $searchTerm->toHtml();
     }
 }

--- a/classes/blocks/NostoSearchTagging.php
+++ b/classes/blocks/NostoSearchTagging.php
@@ -40,7 +40,7 @@ class NostoSearchTagging
             return null;
         }
         $searchTerm = new SearchTerm($searchQuery);
-        if (!NostoHelperConfig::isTaggingEncodingEnabled()) {
+        if (!NostoHelperConfig::isSearchTermEscapingEnabled()) {
             $searchTerm->disableAutoEncodeAll();
         }
         return $searchTerm->toHtml();

--- a/classes/helpers/NostoHelperConfig.php
+++ b/classes/helpers/NostoHelperConfig.php
@@ -35,7 +35,7 @@ class NostoHelperConfig
     const MULTI_CURRENCY_METHOD = 'NOSTOTAGGING_MC_METHOD';
     const SKU_SWITCH = 'NOSTOTAGGING_SKU_SWITCH';
     const CART_UPDATE_SWITCH = 'NOSTOTAGGING_CART_UPDATE_SWITCH';
-    const TAGGING_ENCODING_SWITCH = 'NOSTOTAGGING_ENCODING';
+    const ESCAPE_SEARCH_TERMS_SWITCH = 'NOSTOTAGGING_ESCAPE_SEARCH_TERMS';
     const SKIP_CUSTOMER_TAGGING_SWITCH = 'NOSTOTAGGING_SKIP_CUSTOMER_TAGGING_SWITCH';
     const VARIATION_SWITCH = 'NOSTOTAGGING_VARIATION_SWITCH';
     const VARIATION_TAX_RULE_SWITCH = 'NOSTOTAGGING_TAX_RULE_SWITCH';
@@ -312,13 +312,13 @@ class NostoHelperConfig
     }
 
     /**
-     * Checks if tagging encoding should be enabled
+     * Checks if search term tagging escaping should be enabled
      *
      * @return bool enabled/disabled
      */
-    public static function isTaggingEncodingEnabled()
+    public static function isSearchTermEscapingEnabled()
     {
-        return (bool)self::read(self::TAGGING_ENCODING_SWITCH);
+        return (bool)self::read(self::ESCAPE_SEARCH_TERMS_SWITCH);
     }
 
     /**
@@ -384,16 +384,16 @@ class NostoHelperConfig
     }
 
     /**
-     * Saves enable/disable for tagging encoding
+     * Saves enable/disable for search term tagging escaping
      *
      * @param bool $enabled
      * @return bool true if saving the configuration was successful, false otherwise
      */
-    public static function saveTaggingEncodingEnabled($enabled)
+    public static function saveEscapeSearchTerms($enabled)
     {
         $default = $enabled ? '0' : '1';
-        
-        return self::saveSetting(self::TAGGING_ENCODING_SWITCH, $default);
+
+        return self::saveSetting(self::ESCAPE_SEARCH_TERMS_SWITCH, $default);
     }
 
     /**

--- a/classes/helpers/NostoHelperConfig.php
+++ b/classes/helpers/NostoHelperConfig.php
@@ -35,7 +35,7 @@ class NostoHelperConfig
     const MULTI_CURRENCY_METHOD = 'NOSTOTAGGING_MC_METHOD';
     const SKU_SWITCH = 'NOSTOTAGGING_SKU_SWITCH';
     const CART_UPDATE_SWITCH = 'NOSTOTAGGING_CART_UPDATE_SWITCH';
-    const ESCAPE_SEARCH_TERMS_SWITCH = 'NOSTOTAGGING_ESCAPE_SEARCH_TERMS';
+    const DISABLE_ESCAPE_SEARCH_TERMS_SWITCH = 'NOSTOTAGGING_DISABLE_ESCAPE_SEARCH_TERMS';
     const SKIP_CUSTOMER_TAGGING_SWITCH = 'NOSTOTAGGING_SKIP_CUSTOMER_TAGGING_SWITCH';
     const VARIATION_SWITCH = 'NOSTOTAGGING_VARIATION_SWITCH';
     const VARIATION_TAX_RULE_SWITCH = 'NOSTOTAGGING_TAX_RULE_SWITCH';
@@ -316,9 +316,9 @@ class NostoHelperConfig
      *
      * @return bool enabled/disabled
      */
-    public static function isSearchTermEscapingEnabled()
+    public static function isSearchTermEscapingDisabled()
     {
-        return (bool)self::read(self::ESCAPE_SEARCH_TERMS_SWITCH);
+        return (bool)self::read(self::DISABLE_ESCAPE_SEARCH_TERMS_SWITCH);
     }
 
     /**
@@ -389,11 +389,9 @@ class NostoHelperConfig
      * @param bool $enabled
      * @return bool true if saving the configuration was successful, false otherwise
      */
-    public static function saveEscapeSearchTerms($enabled)
+    public static function saveDisableEscapeSearchTerms($enabled)
     {
-        $default = $enabled ? '0' : '1';
-
-        return self::saveSetting(self::ESCAPE_SEARCH_TERMS_SWITCH, $default);
+        return self::saveSetting(self::DISABLE_ESCAPE_SEARCH_TERMS_SWITCH, $enabled);
     }
 
     /**

--- a/classes/helpers/NostoHelperConfig.php
+++ b/classes/helpers/NostoHelperConfig.php
@@ -35,6 +35,7 @@ class NostoHelperConfig
     const MULTI_CURRENCY_METHOD = 'NOSTOTAGGING_MC_METHOD';
     const SKU_SWITCH = 'NOSTOTAGGING_SKU_SWITCH';
     const CART_UPDATE_SWITCH = 'NOSTOTAGGING_CART_UPDATE_SWITCH';
+    const TAGGING_ENCODING_SWITCH = 'NOSTOTAGGING_ENCODING';
     const SKIP_CUSTOMER_TAGGING_SWITCH = 'NOSTOTAGGING_SKIP_CUSTOMER_TAGGING_SWITCH';
     const VARIATION_SWITCH = 'NOSTOTAGGING_VARIATION_SWITCH';
     const VARIATION_TAX_RULE_SWITCH = 'NOSTOTAGGING_TAX_RULE_SWITCH';
@@ -311,6 +312,16 @@ class NostoHelperConfig
     }
 
     /**
+     * Checks if tagging encoding should be enabled
+     *
+     * @return bool enabled/disabled
+     */
+    public static function isTaggingEncodingEnabled()
+    {
+        return (bool)self::read(self::TAGGING_ENCODING_SWITCH);
+    }
+
+    /**
      * Returns the position where to render Nosto tagging
      *
      * @return string
@@ -370,6 +381,17 @@ class NostoHelperConfig
     public static function saveCartUpdateEnabled($enabled)
     {
         return self::saveSetting(self::CART_UPDATE_SWITCH, $enabled);
+    }
+
+    /**
+     * Saves enable/disable for tagging encoding
+     *
+     * @param bool $enabled
+     * @return bool true if saving the configuration was successful, false otherwise
+     */
+    public static function saveTaggingEncodingEnabled($enabled)
+    {
+        return self::saveSetting(self::TAGGING_ENCODING_SWITCH, $enabled);
     }
 
     /**

--- a/classes/helpers/NostoHelperConfig.php
+++ b/classes/helpers/NostoHelperConfig.php
@@ -391,7 +391,9 @@ class NostoHelperConfig
      */
     public static function saveTaggingEncodingEnabled($enabled)
     {
-        return self::saveSetting(self::TAGGING_ENCODING_SWITCH, $enabled);
+        $default = $enabled ? '0' : '1';
+        
+        return self::saveSetting(self::TAGGING_ENCODING_SWITCH, $default);
     }
 
     /**

--- a/controllers/admin/NostoAdvancedSettingController.php
+++ b/controllers/admin/NostoAdvancedSettingController.php
@@ -42,6 +42,7 @@ class NostoAdvancedSettingController extends NostoBaseController
         NostoHelperConfig::saveVariationEnabled(Tools::getValue('nosto_variation_switch'));
         NostoHelperConfig::saveVariationTaxRuleEnabled(Tools::getValue('nosto_variation_tax_rule_switch'));
         NostoHelperConfig::saveCartUpdateEnabled(Tools::getValue('nosto_cart_update_switch'));
+        NostoHelperConfig::saveTaggingEncodingEnabled(Tools::getValue('nosto_tagging_encoding'));
         NostoHelperConfig::saveCustomerTaggingEnabled(Tools::getValue('nosto_customer_tagging_switch'));
 
         $account = NostoHelperAccount::getAccount();

--- a/controllers/admin/NostoAdvancedSettingController.php
+++ b/controllers/admin/NostoAdvancedSettingController.php
@@ -42,8 +42,10 @@ class NostoAdvancedSettingController extends NostoBaseController
         NostoHelperConfig::saveVariationEnabled(Tools::getValue('nosto_variation_switch'));
         NostoHelperConfig::saveVariationTaxRuleEnabled(Tools::getValue('nosto_variation_tax_rule_switch'));
         NostoHelperConfig::saveCartUpdateEnabled(Tools::getValue('nosto_cart_update_switch'));
-        NostoHelperConfig::saveEscapeSearchTerms(Tools::getValue('nosto_tagging_escape_search_terms_switch'));
         NostoHelperConfig::saveCustomerTaggingEnabled(Tools::getValue('nosto_customer_tagging_switch'));
+        NostoHelperConfig::saveDisableEscapeSearchTerms(
+            Tools::getValue('nosto_tagging_disable_escape_search_terms_switch')
+        );
 
         $account = NostoHelperAccount::getAccount();
         $accountMeta = NostoAccountSignup::loadData();

--- a/controllers/admin/NostoAdvancedSettingController.php
+++ b/controllers/admin/NostoAdvancedSettingController.php
@@ -42,7 +42,7 @@ class NostoAdvancedSettingController extends NostoBaseController
         NostoHelperConfig::saveVariationEnabled(Tools::getValue('nosto_variation_switch'));
         NostoHelperConfig::saveVariationTaxRuleEnabled(Tools::getValue('nosto_variation_tax_rule_switch'));
         NostoHelperConfig::saveCartUpdateEnabled(Tools::getValue('nosto_cart_update_switch'));
-        NostoHelperConfig::saveTaggingEncodingEnabled(Tools::getValue('nosto_tagging_encoding'));
+        NostoHelperConfig::saveEscapeSearchTerms(Tools::getValue('nosto_tagging_escape_search_terms_switch'));
         NostoHelperConfig::saveCustomerTaggingEnabled(Tools::getValue('nosto_customer_tagging_switch'));
 
         $account = NostoHelperAccount::getAccount();

--- a/controllers/admin/NostoIndexController.php
+++ b/controllers/admin/NostoIndexController.php
@@ -179,7 +179,7 @@ class NostoIndexController
             'nostotagging_position' => NostoHelperConfig::getNostotaggingRenderPosition(),
             'nostotagging_variation_switch' => NostoHelperConfig::getVariationEnabled(),
             'nostotagging_variation_tax_rule_switch' => NostoHelperConfig::getVariationTaxRuleEnabled(),
-            'nosto_tagging_encoding_switch' => NostoHelperConfig::isSearchTermEscapingEnabled(),
+            'nosto_tagging_disable_escape_search_terms_switch' => NostoHelperConfig::isSearchTermEscapingDisabled(),
             'nostotagging_ps_version_class' => 'ps-' . str_replace(
                 '.',
                 '',

--- a/controllers/admin/NostoIndexController.php
+++ b/controllers/admin/NostoIndexController.php
@@ -179,7 +179,7 @@ class NostoIndexController
             'nostotagging_position' => NostoHelperConfig::getNostotaggingRenderPosition(),
             'nostotagging_variation_switch' => NostoHelperConfig::getVariationEnabled(),
             'nostotagging_variation_tax_rule_switch' => NostoHelperConfig::getVariationTaxRuleEnabled(),
-            'nosto_tagging_encoding_switch' => NostoHelperConfig::isTaggingEncodingEnabled(),
+            'nosto_tagging_encoding_switch' => NostoHelperConfig::isSearchTermEscapingEnabled(),
             'nostotagging_ps_version_class' => 'ps-' . str_replace(
                 '.',
                 '',

--- a/controllers/admin/NostoIndexController.php
+++ b/controllers/admin/NostoIndexController.php
@@ -179,6 +179,7 @@ class NostoIndexController
             'nostotagging_position' => NostoHelperConfig::getNostotaggingRenderPosition(),
             'nostotagging_variation_switch' => NostoHelperConfig::getVariationEnabled(),
             'nostotagging_variation_tax_rule_switch' => NostoHelperConfig::getVariationTaxRuleEnabled(),
+            'nosto_tagging_encoding_switch' => NostoHelperConfig::isTaggingEncodingEnabled(),
             'nostotagging_ps_version_class' => 'ps-' . str_replace(
                 '.',
                 '',

--- a/nostotagging.php
+++ b/nostotagging.php
@@ -56,7 +56,7 @@ class NostoTagging extends Module
      *
      * @var string
      */
-    const PLUGIN_VERSION = '3.7.1';
+    const PLUGIN_VERSION = '3.7.2';
 
     /**
      * Internal name of the Nosto plug-in

--- a/nostotagging.php
+++ b/nostotagging.php
@@ -56,7 +56,7 @@ class NostoTagging extends Module
      *
      * @var string
      */
-    const PLUGIN_VERSION = '3.7.2';
+    const PLUGIN_VERSION = '3.8.0';
 
     /**
      * Internal name of the Nosto plug-in

--- a/views/templates/admin/config-bootstrap.tpl
+++ b/views/templates/admin/config-bootstrap.tpl
@@ -297,19 +297,19 @@
                                 </span>
                             </div>
                         </div>
-                        <!-- Tagging Encoding Switch -->
+                        <!-- Escape search terms switch -->
                         <div class="form-group" id="nosto_variation_tax_rule_switch_div">
                             <label class="control-label col-lg-3">
-                                <span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='Auto encode tagging' mod='nostotagging'}" data-html="true">
-                                    {l s='Auto Encode Tagging' mod='nostotagging'}
+                                <span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='Escape search terms' mod='nostotagging'}" data-html="true">
+                                    {l s='Escape search terms' mod='nostotagging'}
                                 </span>
                             </label>
                             <div class="col-lg-9">
                                 <span class="switch prestashop-switch fixed-width-lg">
-                                    <input type="radio" name="nosto_tagging_encoding" id="nosto_tagging_encoding_on"  value="1" {if $nosto_tagging_encoding_switch === true}checked="checked" {/if}/>
-                                    <label for="nosto_tagging_encoding_on" class="radioCheck">Yes</label>
-                                    <input type="radio" name="nosto_tagging_encoding" id="nosto_tagging_encoding_off" value="0" {if $nosto_tagging_encoding_switch !== true}checked="checked" {/if}/>
-                                    <label for="nosto_tagging_encoding_off" class="radioCheck">No</label>
+                                    <input type="radio" name="nosto_tagging_search_term_escaping" id="nosto_tagging_search_term_escaping_on"  value="1" {if $nosto_tagging_escape_search_terms_switch === true}checked="checked" {/if}/>
+                                    <label for="nosto_tagging_search_term_escaping_on" class="radioCheck">Yes</label>
+                                    <input type="radio" name="nosto_tagging_search_term_escaping" id="nosto_tagging_search_term_escaping_off" value="0" {if $nosto_tagging_escape_search_terms_switch !== true}checked="checked" {/if}/>
+                                    <label for="nosto_tagging_search_term_escaping_off" class="radioCheck">No</label>
                                     <a class="slide-button btn"></a>
                                 </span>
                             </div>

--- a/views/templates/admin/config-bootstrap.tpl
+++ b/views/templates/admin/config-bootstrap.tpl
@@ -297,6 +297,23 @@
                                 </span>
                             </div>
                         </div>
+                        <!-- Tagging Encoding Switch -->
+                        <div class="form-group" id="nosto_variation_tax_rule_switch_div">
+                            <label class="control-label col-lg-3">
+                                <span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='Auto encode tagging' mod='nostotagging'}" data-html="true">
+                                    {l s='Auto Encode Tagging' mod='nostotagging'}
+                                </span>
+                            </label>
+                            <div class="col-lg-9">
+                                <span class="switch prestashop-switch fixed-width-lg">
+                                    <input type="radio" name="nosto_tagging_encoding" id="nosto_tagging_encoding_on"  value="1" {if $nosto_tagging_encoding_switch === true}checked="checked" {/if}/>
+                                    <label for="nosto_tagging_encoding_on" class="radioCheck">Yes</label>
+                                    <input type="radio" name="nosto_tagging_encoding" id="nosto_tagging_encoding_off" value="0" {if $nosto_tagging_encoding_switch !== true}checked="checked" {/if}/>
+                                    <label for="nosto_tagging_encoding_off" class="radioCheck">No</label>
+                                    <a class="slide-button btn"></a>
+                                </span>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div class="panel-footer"  style="display:none;margin-bottom: 10px;"">

--- a/views/templates/admin/config-bootstrap.tpl
+++ b/views/templates/admin/config-bootstrap.tpl
@@ -300,16 +300,16 @@
                         <!-- Escape search terms switch -->
                         <div class="form-group" id="nosto_variation_tax_rule_switch_div">
                             <label class="control-label col-lg-3">
-                                <span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='Escape search terms' mod='nostotagging'}" data-html="true">
-                                    {l s='Escape search terms' mod='nostotagging'}
+                                <span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='Disable escape search terms' mod='nostotagging'}" data-html="true">
+                                    {l s='Disable escape search terms' mod='nostotagging'}
                                 </span>
                             </label>
                             <div class="col-lg-9">
                                 <span class="switch prestashop-switch fixed-width-lg">
-                                    <input type="radio" name="nosto_tagging_search_term_escaping" id="nosto_tagging_search_term_escaping_on"  value="1" {if $nosto_tagging_escape_search_terms_switch === true}checked="checked" {/if}/>
-                                    <label for="nosto_tagging_search_term_escaping_on" class="radioCheck">Yes</label>
-                                    <input type="radio" name="nosto_tagging_search_term_escaping" id="nosto_tagging_search_term_escaping_off" value="0" {if $nosto_tagging_escape_search_terms_switch !== true}checked="checked" {/if}/>
-                                    <label for="nosto_tagging_search_term_escaping_off" class="radioCheck">No</label>
+                                    <input type="radio" name="nosto_tagging_disable_escape_search_terms_switch" id="nosto_tagging_disable_escape_search_terms_switch_on"  value="1" {if $nosto_tagging_disable_escape_search_terms_switch === true}checked="checked" {/if}/>
+                                    <label for="nosto_tagging_disable_escape_search_terms_switch_on" class="radioCheck">Yes</label>
+                                    <input type="radio" name="nosto_tagging_disable_escape_search_terms_switch" id="nosto_tagging_disable_escape_search_terms_switch_off" value="0" {if $nosto_tagging_disable_escape_search_terms_switch !== true}checked="checked" {/if}/>
+                                    <label for="nosto_tagging_disable_escape_search_terms_switch_off" class="radioCheck">No</label>
                                     <a class="slide-button btn"></a>
                                 </span>
                             </div>


### PR DESCRIPTION
## Description
Add feature flag to disable auto encoding of search terms

## Related Issue
Fixes #301 

## Motivation and Context
It seems that Prestashop escapes the search term in some versions automatically and in some versions, it doesn't

## How Has This Been Tested?
- [x] Prestashop 1.6
- [x] Prestashop 1.7

## Documentation:
N/A

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non-existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities
