### PR TITLE
loadRecommendations race condition

### DIFF
--- a/views/templates/hook/partials/js-auto-slots-inline.tpl
+++ b/views/templates/hook/partials/js-auto-slots-inline.tpl
@@ -50,8 +50,14 @@
                                 slotsMoved = true;
                             }
                         });
-                        if (slotsMoved && nostoRecosLoaded) {
-                            api.loadRecommendations();
+                        if (slotsMoved) {
+                            if (nostoRecosLoaded) {
+                                api.loadRecommendations();
+                            } else {
+                                api.listen('postrender', function () {
+                                    api.loadRecommendations();
+                                });
+                            }
                         }
                     }
                 };


### PR DESCRIPTION
In cases where if nostoRecosLoaded changes state before the slots finish moving, the recommendations won't load.